### PR TITLE
Solucionados Bugs refrentes a Safari y otros navegadores móviles

### DIFF
--- a/src/components/register/InputCheckbox.tsx
+++ b/src/components/register/InputCheckbox.tsx
@@ -26,7 +26,7 @@ export default function InputCheckbox({ id, label, required = false, tooltip }: 
         {tooltip && (
           <div className="group relative flex items-center" tabIndex={0}>
             <FontAwesomeIcon icon={faInfoCircle} className="h-4 w-4 cursor-pointer text-white/50" />
-            <div className="absolute left-0 top-full z-10 mt-1 hidden w-max max-w-xs rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
+            <div className="absolute left-1/2 top-full z-10 mt-1 hidden w-max max-w-xs -translate-x-1/2 rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
               {tooltip}
             </div>
           </div>

--- a/src/components/register/InputFile.tsx
+++ b/src/components/register/InputFile.tsx
@@ -19,7 +19,7 @@ export default function InputFile({ id, label, required = false, accept, tooltip
         {tooltip && (
           <div className="group relative flex items-center" tabIndex={0}>
             <FontAwesomeIcon icon={faInfoCircle} className="h-4 w-4 cursor-pointer text-white/50" />
-            <div className="absolute left-0 top-full z-10 mt-1 hidden w-max max-w-xs rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
+            <div className="absolute left-1/2 top-full z-10 mt-1 hidden w-max max-w-xs -translate-x-1/2 rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
               {tooltip}
             </div>
           </div>

--- a/src/components/register/InputSelect.tsx
+++ b/src/components/register/InputSelect.tsx
@@ -36,7 +36,7 @@ export default function InputSelect({
         {tooltip && (
           <div className="group relative flex items-center" tabIndex={0}>
             <FontAwesomeIcon icon={faInfoCircle} className="h-4 w-4 cursor-pointer text-white/50" />
-            <div className="absolute left-0 top-full z-10 mt-1 hidden w-max max-w-xs rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
+            <div className="absolute left-1/2 top-full z-10 mt-1 hidden w-max max-w-xs -translate-x-1/2 rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
               {tooltip}
             </div>
           </div>

--- a/src/components/register/InputText.tsx
+++ b/src/components/register/InputText.tsx
@@ -31,7 +31,7 @@ export default function InputText({
         {tooltip && (
           <div className="group relative flex items-center" tabIndex={0} aria-label={tooltip}>
             <FontAwesomeIcon icon={faInfoCircle} className="h-4 w-4 cursor-pointer text-white/50" />
-            <div className="absolute left-0 top-full z-10 mt-1 hidden w-max max-w-xs rounded-lg bg-black p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
+            <div className="absolute left-1/2 top-full z-10 mt-1 hidden w-max max-w-xs -translate-x-1/2 rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
               {tooltip}
             </div>
           </div>

--- a/src/components/register/InputTextArea.tsx
+++ b/src/components/register/InputTextArea.tsx
@@ -23,7 +23,7 @@ export default function InputText({ id, label, required = false, placeholder = '
         {tooltip && (
           <div className="group relative flex items-center" tabIndex={0} aria-label={tooltip}>
             <FontAwesomeIcon icon={faInfoCircle} className="h-4 w-4 cursor-pointer text-white/50" />
-            <div className="absolute left-0 top-full z-10 mt-1 hidden w-max max-w-xs rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
+            <div className="absolute left-1/2 top-full z-10 mt-1 hidden w-max max-w-xs -translate-x-1/2 rounded-lg bg-gray-800/90 p-2 text-xs text-white shadow-md group-hover:block group-focus:block">
               {tooltip}
             </div>
           </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -60,5 +60,14 @@ const { title, light = false } = Astro.props
     body {
       font-family: 'Roboto', sans-serif;
     }
+    @supports (-webkit-appearance: none) and (-webkit-backdrop-filter: none) {
+      select {
+        -webkit-appearance: none;
+      }
+      input[type="date"] {
+        -webkit-appearance: none;
+        height: 3rem;
+      }
+    }
   </style>
 </html>


### PR DESCRIPTION
El Tooltip provocaba en pantallas pequeñas que todo el formulario "desapareciera" (se desplazara a la izquierda) de la pantalla al intentar leerlo. Para solucionarlo he centrado los tooltips y así se mitiga parcialmente el problema.

En Safari existía un bug en el que el texto se sobreponía sobre los iconos y los inputs por defecto de Safari no se modificaban correctamente con el estilo. Aunque es una solución algo bruta creé un estilo global para que en los navegadores safaris los inputs se vean correctamente.